### PR TITLE
Remove old source modifications

### DIFF
--- a/0.19/Dockerfile
+++ b/0.19/Dockerfile
@@ -90,13 +90,6 @@ FROM from-${SOURCE} AS bitcoin-core
 # Change to the extracted directory
 WORKDIR /bitcoin-${BITCOIN_VERSION}
 
-# ???
-RUN sed -i '/AC_PREREQ/a\AR_FLAGS=cr' src/univalue/configure.ac
-# ???
-RUN sed -i '/AX_PROG_CC_FOR_BUILD/a\AR_FLAGS=cr' src/secp256k1/configure.ac
-# ???
-RUN sed -i s:sys/fcntl.h:fcntl.h: src/compat.h
-
 ENV BITCOIN_PREFIX="/opt/bitcoin-${BITCOIN_VERSION}"
 
 RUN ./autogen.sh


### PR DESCRIPTION
I'm not sure what these modifications are for or why they were added initially but `bitcoind` seems to build and run fine without them.

I can sync some blocks with `bitcoind` and query with `bitcoin-cli` without issue.

Obviously we should make sure we understand why these changes were added and if it's safe to remove them before we merge this.