### PR TITLE
Run qemu-perf action

### DIFF
--- a/.github/workflows/qemu-perf.yml
+++ b/.github/workflows/qemu-perf.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '2 1 * * *'
 
+  push:
+    branches:
+      - qemu
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
While `cron` was defined, it never run…  Perhaps it needs to be run somehow else first.  Also added a way to manually trigger it (push to `qemu` branch).

Resolves #25

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lncm/docker-bitcoind/27)
<!-- Reviewable:end -->
