### PR TITLE
Testing for bitcoin 0.21.1

### DIFF
--- a/0.21/Dockerfile
+++ b/0.21/Dockerfile
@@ -3,7 +3,7 @@
 # VERSION of Bitcoin Core to be build
 #   NOTE: Unlike our other images this one is NOT prefixed with `v`,
 #           as many things (like download URLs) use this form instead.
-ARG VERSION=0.21.0
+ARG VERSION=0.21.1
 
 
 # CPU architecture to build binaries for

--- a/0.21/Dockerfile
+++ b/0.21/Dockerfile
@@ -57,7 +57,7 @@ ARG VERSION
 ADD https://bitcoincore.org/bin/bitcoin-core-$VERSION/SHA256SUMS.asc  ./
 
 # Download source code (intentionally different website than checksums)
-ADD https://bitcoin.org/bin/bitcoin-core-$VERSION/bitcoin-$VERSION.tar.gz ./
+ADD https://bitcoincore.org/bin/bitcoin-core-$VERSION/bitcoin-$VERSION.tar.gz ./
 
 # Verify that hashes are signed with the previously imported key
 RUN gpg --verify SHA256SUMS.asc


### PR DESCRIPTION
Test pull request for bitcoin 0.21.1 (taproot activation).

* Including changes suggested from @AaronDewes  
* Using bitcoincore.org instead of bitcoin.org as the sources are not available yet. I don't see why we can't use that change as the sources are on there anyway.  But maybe it was intended because to be more decentralized (/cc @meeDamian  ?)