### PR TITLE
Update to 23.1

### DIFF
--- a/23.0/Dockerfile
+++ b/23.0/Dockerfile
@@ -3,7 +3,7 @@
 # VERSION of Bitcoin Core to be build
 #   NOTE: Unlike our other images this one is NOT prefixed with `v`,
 #           as many things (like download URLs) use this form instead.
-ARG VERSION=23.0
+ARG VERSION=23.1
 
 # CPU architecture to build binaries for
 ARG ARCH


### PR DESCRIPTION
Now, the folder is called 23.0 but the version in the Dockerfile is 23.1 now...

Release notes: https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-23.1.md