### PR TITLE
25.0: remove Boost libraries

### DIFF
--- a/24.0/Dockerfile
+++ b/24.0/Dockerfile
@@ -217,8 +217,6 @@ LABEL maintainer="Damian Mee (@meeDamian)"
 RUN sed -i 's|http://dl-cdn.alpinelinux.org|https://alpine.global.ssl.fastly.net|g' /etc/apk/repositories
 
 RUN apk add --no-cache \
-        boost-filesystem \
-        boost-thread \
         libevent \
         libsodium \
         libstdc++ \

--- a/25.0/Dockerfile
+++ b/25.0/Dockerfile
@@ -217,8 +217,6 @@ LABEL maintainer="Damian Mee (@meeDamian)"
 RUN sed -i 's|http://dl-cdn.alpinelinux.org|https://alpine.global.ssl.fastly.net|g' /etc/apk/repositories
 
 RUN apk add --no-cache \
-        boost-filesystem \
-        boost-thread \
         libevent \
         libsodium \
         libstdc++ \


### PR DESCRIPTION
Neither of these are required to run at least Bitcoin Core 25.0 or 24.0, see https://github.com/bitcoin/bitcoin/pull/21064 and https://github.com/bitcoin/bitcoin/pull/20744.