### PR TITLE
test: remove long-EOL branches from CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         subver:
-          - '0.16'
-          - '0.17'
-          - '0.18'
-          - '0.19'
-          - '0.20'
-          - '0.21'
           - '22.0'
           - '23.0'
           - '24.0'
@@ -73,11 +67,7 @@ jobs:
           run bitcoind | head -n 1
           run bitcoin-cli
           run bitcoin-tx --help | head -n 1
-
-          # If version higher, or equal than v0.18.0, also run `bitcoin-wallet` binary
-          if [ "${MINOR#0.}" -ge "18" ]; then
-            run bitcoin-wallet --help | head -n 1
-          fi
+          run bitcoin-wallet --help | head -n 1
 
           run uname -a
           run cat /etc/os-release


### PR DESCRIPTION
Rather than building many, end of life branches, everytime a new PR is opened, slim the test matrix down to more recent versions.

Note that even `v22.0` is now end of life, and wont be receiving any further updates: https://bitcoincore.org/en/lifecycle/#schedule, however I've left that as-is for now, given #81.