### PR TITLE
0.21: update to 0.21.2

### DIFF
--- a/0.21/Dockerfile
+++ b/0.21/Dockerfile
@@ -3,7 +3,7 @@
 # VERSION of Bitcoin Core to be build
 #   NOTE: Unlike our other images this one is NOT prefixed with `v`,
 #           as many things (like download URLs) use this form instead.
-ARG VERSION=0.21.1
+ARG VERSION=0.21.2
 
 
 # CPU architecture to build binaries for


### PR DESCRIPTION
Rel notes:
https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.21.2.md.

0.21 is EOL, but if this image is going to continue to exist, it might as well be serving the most recent point release from this branch.